### PR TITLE
add syscalls that are likely to be used in 32 bit architectures

### DIFF
--- a/sandbox.c
+++ b/sandbox.c
@@ -28,6 +28,7 @@
 #elif __linux
 #include <sys/resource.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
 
 #include <linux/audit.h>
 #include <linux/filter.h>
@@ -128,7 +129,15 @@ static const struct sock_filter child_insns[] = {
 	SC_ALLOW(close),
 	SC_ALLOW(exit_group),
 	SC_ALLOW(fstat),
+#ifdef SYS_fstat64
+	SC_ALLOW(fstat64),
+#endif
+#ifdef SYS_mmap
 	SC_ALLOW(mmap),
+#endif
+#ifdef SYS_mmap2
+	SC_ALLOW(mmap2),
+#endif
 	SC_ALLOW(munmap),
 	SC_ALLOW(read),
 	SC_ALLOW(recvmsg),


### PR DESCRIPTION
Linux 32 bit is likely to use the fstat64 syscall with a modern libc; it is also possible it will use mmap2 which allows mmap with longer off_t.

Some architectures only have mmap not mmap2.