### PR TITLE
Fixed magic for AIN archive

### DIFF
--- a/magic
+++ b/magic
@@ -2306,8 +2306,8 @@
 1	string	\0\xae\3 BSN archive data
 1	string	\0\xae\7 BSN archive data
 # AIN
-0	string	\x33\x18 AIN archive data
-0	string	\x33\x17 AIN archive data
+0	string	\x21\x12\0\0\0\0\0\0 AIN archive data
+0	string	\x21\x11\0\0\0\0\0\0 AIN archive data
 # XPA32 test moved and merged with XPA by Joerg Jenderek at Sep 2015
 # SZip (TODO: doesn't catch all versions)
 0	string	SZ\x0a\4 SZip archive data
@@ -3437,7 +3437,7 @@
 >>12		ulelong		x		\b, sample rate %d
 
 # adlib sound files
-# From Gürkan Sengün <gurkan@linuks.mine.nu>, http://www.linuks.mine.nu
+# From GÃ¼rkan SengÃ¼n <gurkan@linuks.mine.nu>, http://www.linuks.mine.nu
 0    	string		RAWADATA	RdosPlay RAW
 
 1068	string		RoR		AMUSIC Adlib Tracker
@@ -4554,7 +4554,7 @@
 >113	string	x		(%s)
 
 #------------------------------------------------------------------------------
-# Microsoft Xbox executables .xbe (Esa Hyytiä <ehyytia@cc.hut.fi>)
+# Microsoft Xbox executables .xbe (Esa HyytiÃ¤ <ehyytia@cc.hut.fi>)
 0       string          XBEH            XBE, Microsoft Xbox executable
 # probabilistic checks whether signed or not
 >0x0004 ulelong =0x0
@@ -4590,7 +4590,7 @@
 # From: Serge van den Boom <svdb@stack.nl>
 0	string		\x01ZZZZZ\x01	3DO "Opera" file system
 
-# From Gürkan Sengün <gurkan@linuks.mine.nu>, www.linuks.mine.nu
+# From GÃ¼rkan SengÃ¼n <gurkan@linuks.mine.nu>, www.linuks.mine.nu
 0	string		GBS		Nintendo Gameboy Music/Audio Data
 12	string		GameBoy\ Music\ Module	Nintendo Gameboy Music Module
 
@@ -6806,8 +6806,8 @@
 #        10	SS, 8 SPT
 #        11	DS, 8 SPT
 #
-#  11111001	Double density 3� floppy disk, high density 5�
-#  11110000	High density 3� floppy disk
+#  11111001	Double density 3½ floppy disk, high density 5¼
+#  11110000	High density 3½ floppy disk
 #  11111000	Hard disk any format
 #
 
@@ -7048,7 +7048,7 @@
 # Opentype font data from Avi Bercovich
 0	string		OTTO		OpenType font data 
 
-# Gürkan Sengün <gurkan@linuks.mine.nu>, www.linuks.mine.nu 
+# GÃ¼rkan SengÃ¼n <gurkan@linuks.mine.nu>, www.linuks.mine.nu 
 0	string		SplineFontDB:	Spline Font Database 
 >14	string		x		version %s
 #	$OpenBSD: fortran,v 1.2 2009/04/26 14:17:45 chl Exp $
@@ -8624,7 +8624,7 @@
 >5	byte	0x00		(white background)
 >5	byte	0xFF		(black background)
 
-# Gürkan Sengün <gurkan@linuks.mine.nu>, www.linuks.mine.nu
+# GÃ¼rkan SengÃ¼n <gurkan@linuks.mine.nu>, www.linuks.mine.nu
 # http://www.atarimax.com/jindroush.atari.org/afmtatr.html
 0	leshort	0x0296		Atari ATR image
 
@@ -8920,7 +8920,7 @@
 
 # rom: file(1) magic for BIOS ROM Extensions found in intel machines
 #      mapped into memory between 0xC0000 and 0xFFFFF
-# From Gürkan Sengün <gurkan@linuks.mine.nu>, www.linuks.mine.nu
+# From GÃ¼rkan SengÃ¼n <gurkan@linuks.mine.nu>, www.linuks.mine.nu
 0        beshort         0x55AA       BIOS (ia32) ROM Ext.
 >5       string          USB          USB
 >7       string          LDR          UNDI image
@@ -9335,7 +9335,7 @@
 #
 # Linux kernel boot images, from Albert Cahalan <acahalan@cs.uml.edu>
 # and others such as Axel Kohlmeyer <akohlmey@rincewind.chemie.uni-ulm.de>
-# and Nicol�s Lichtmaier <nick@debian.org>
+# and Nicolás Lichtmaier <nick@debian.org>
 # All known start with: b8 c0 07 8e d8 b8 00 90 8e c0 b9 00 01 29 f6 29
 # Linux kernel boot images (i386 arch) (Wolfram Kleff)
 514	string		HdrS		Linux kernel
@@ -9358,10 +9358,10 @@
 >0x1e3		string	Loading		version 1.3.79 or older
 >0x1e9		string	Loading		from prehistoric times
 
-# System.map files - Nicol�s Lichtmaier <nick@debian.org>
+# System.map files - Nicolás Lichtmaier <nick@debian.org>
 8	search/1	\ A\ _text	Linux kernel symbol map text
 
-# LSM entries - Nicol�s Lichtmaier <nick@debian.org>
+# LSM entries - Nicolás Lichtmaier <nick@debian.org>
 0	search/1	Begin3	Linux Software Map entry text
 0	search/1	Begin4	Linux Software Map entry text (new format)
 
@@ -12754,7 +12754,7 @@
 #
 #	http://www.seanet.com/users/matts/riffmci/riffmci.htm
 #
-# AVI section extended by Patrik R�dman <patrik+file-magic@iki.fi>
+# AVI section extended by Patrik Rådman <patrik+file-magic@iki.fi>
 #
 0	string		RIFF		RIFF (little-endian) data
 # RIFF Palette format
@@ -15404,7 +15404,7 @@
 512	string		R\0o\0o\0t\0	Hangul (Korean) Word Processor File 2000
 !:mime	application/x-hwp
 
-# CosmicBook, from Beno�t Rouits
+# CosmicBook, from Benoît Rouits
 0       string  CSBK    Ted Neslson's CosmicBook hypertext file
 
 2       string  EYWR    AmigaWriter file


### PR DESCRIPTION
Reference

* http://fileformats.archiveteam.org/wiki/AIN
* JUP.DAT in JUP at https://weynans.lima-city.de/tools-en.htm

(Sorry about the changes of non-ASCII characters. They were introduced by the editor on github.com, without an easy way to undo.)